### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,21 @@
+name: Deploy
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: python job_aggregator.py --once
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./static

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Job Aggregator
 
-This project provides a small but extensible job aggregator that scrapes job
-listings from known career pages and exposes them through a REST API. Jobs are
-persisted using SQLAlchemy so any database supported by the library can be used.
+This project provides a small but extensible job aggregator that scrapes job listings from known career pages and exposes them through a REST API. Jobs are persisted using SQLAlchemy so any database supported by the library can be used.
 
 ## Setup
 
@@ -19,9 +17,7 @@ python job_aggregator.py &
 python app.py
 ```
 
-The aggregator will fetch jobs on startup and then once per day. Set the
-`JOB_DB_URL` environment variable to change the database location from the
-default `jobs.db` SQLite file.
+The aggregator will fetch jobs on startup and then once per day. Set the `JOB_DB_URL` environment variable to change the database location from the default `jobs.db` SQLite file.
 
 Open your browser to `http://localhost:5000` to view the React front-end.
 
@@ -31,7 +27,4 @@ Use the search box on the page to filter jobs by company name or job title.
 
 ## Hosting on GitHub Pages
 
-You can deploy the React front-end for free using GitHub Pages. A sample
-workflow is provided in `.github/workflows/pages.yml` that runs the scraper
-daily and publishes the `static` directory. Enable GitHub Pages from the
-`gh-pages` branch to make the site publicly accessible.
+You can deploy the React front-end for free using GitHub Pages. A sample workflow is provided in `.github/workflows/pages.yml` that runs the scraper daily and publishes the `static` directory. Enable GitHub Pages from the `gh-pages` branch to make the site publicly accessible.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# codex_test
+# Job Aggregator
+
+This project provides a small but extensible job aggregator that scrapes job
+listings from known career pages and exposes them through a REST API. Jobs are
+persisted using SQLAlchemy so any database supported by the library can be used.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the job fetcher and web app:
+
+```bash
+python job_aggregator.py &
+python app.py
+```
+
+The aggregator will fetch jobs on startup and then once per day. Set the
+`JOB_DB_URL` environment variable to change the database location from the
+default `jobs.db` SQLite file.
+
+Open your browser to `http://localhost:5000` to view the React front-end.
+
+### Searching
+
+Use the search box on the page to filter jobs by company name or job title.
+
+## Hosting on GitHub Pages
+
+You can deploy the React front-end for free using GitHub Pages. A sample
+workflow is provided in `.github/workflows/pages.yml` that runs the scraper
+daily and publishes the `static` directory. Enable GitHub Pages from the
+`gh-pages` branch to make the site publicly accessible.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,38 @@
+from flask import Flask, request, jsonify, send_from_directory
+from sqlalchemy import create_engine, text
+import os
+
+app = Flask(__name__, static_folder='static', static_url_path='/')
+DB_URL = os.environ.get('JOB_DB_URL', 'sqlite:///jobs.db')
+engine = create_engine(DB_URL, echo=False)
+
+
+def get_jobs(search=None):
+    query = text('SELECT company, title, location, link FROM jobs')
+    params = {}
+    if search:
+        query = text('''SELECT company, title, location, link FROM jobs
+                        WHERE company LIKE :q OR title LIKE :q
+                        ORDER BY timestamp DESC''')
+        params['q'] = f'%{search}%'
+    else:
+        query = text('SELECT company, title, location, link FROM jobs ORDER BY timestamp DESC')
+    with engine.connect() as conn:
+        rows = conn.execute(query, params).fetchall()
+    return [dict(company=r[0], title=r[1], location=r[2], link=r[3]) for r in rows]
+
+
+@app.route('/')
+def index():
+    return send_from_directory(app.static_folder, 'index.html')
+
+
+@app.route('/api/jobs')
+def api_jobs():
+    q = request.args.get('q', '')
+    jobs = get_jobs(q if q else None)
+    return jsonify(jobs)
+
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')

--- a/job_aggregator.py
+++ b/job_aggregator.py
@@ -1,0 +1,129 @@
+"""Job aggregation utilities.
+
+Scrapes job listings from known career sites and stores them in a
+SQLite database using SQLAlchemy. Jobs are refreshed daily via
+APScheduler.
+"""
+
+from datetime import datetime
+import json
+import os
+import requests
+from bs4 import BeautifulSoup
+from apscheduler.schedulers.background import BackgroundScheduler
+from sqlalchemy import create_engine, Column, Integer, String, DateTime, UniqueConstraint
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DB_URL = os.environ.get("JOB_DB_URL", "sqlite:///jobs.db")
+engine = create_engine(DB_URL, echo=False)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
+JOBS_JSON = os.path.join(STATIC_DIR, "jobs.json")
+
+class Job(Base):
+    __tablename__ = "jobs"
+    id = Column(Integer, primary_key=True)
+    company = Column(String, nullable=False)
+    title = Column(String, nullable=False)
+    location = Column(String, nullable=True)
+    link = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    __table_args__ = (UniqueConstraint('link', name='uix_link'),)
+
+def init_db():
+    Base.metadata.create_all(engine)
+
+
+def _fetch_exampleco():
+    """Example scraper for a fictional careers page."""
+    url = "https://example.com/careers"
+    jobs = []
+    try:
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+        for a in soup.select('a[href*="/job/"]'):
+            title = a.get_text(strip=True)
+            link = a['href']
+            if not link.startswith('http'):
+                link = url.rstrip('/') + '/' + link.lstrip('/')
+            location = ""
+            loc = a.find_next(class_='location')
+            if loc:
+                location = loc.get_text(strip=True)
+            jobs.append({
+                'company': 'ExampleCo',
+                'title': title,
+                'location': location,
+                'link': link,
+            })
+    except Exception as exc:
+        print(f"Failed to fetch {url}: {exc}")
+    return jobs
+
+
+SCRAPERS = [_fetch_exampleco]
+
+
+def export_jobs():
+    """Write all jobs to a JSON file for static hosting."""
+    session = SessionLocal()
+    jobs = session.query(Job).order_by(Job.timestamp.desc()).all()
+    data = [
+        {
+            'company': j.company,
+            'title': j.title,
+            'location': j.location,
+            'link': j.link,
+        }
+        for j in jobs
+    ]
+    os.makedirs(STATIC_DIR, exist_ok=True)
+    with open(JOBS_JSON, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+    session.close()
+
+
+def fetch_jobs():
+    """Run all scrapers and store results."""
+    session = SessionLocal()
+    for scraper in SCRAPERS:
+        for job in scraper():
+            exists = session.query(Job).filter_by(link=job['link']).first()
+            if exists:
+                continue
+            session.add(Job(**job))
+    session.commit()
+    export_jobs()
+    session.close()
+
+
+def start_scheduler():
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(fetch_jobs, 'interval', days=1)
+    scheduler.start()
+    return scheduler
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Fetch jobs once and exit without running the scheduler",
+    )
+    args = parser.parse_args()
+
+    init_db()
+    fetch_jobs()
+    if not args.once:
+        start_scheduler()
+        try:
+            while True:
+                pass
+        except (KeyboardInterrupt, SystemExit):
+            pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+requests
+beautifulsoup4
+apscheduler
+sqlalchemy

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,59 @@
+function JobList() {
+  const [jobs, setJobs] = React.useState([]);
+  const [query, setQuery] = React.useState('');
+
+  const fetchJobs = React.useCallback(() => {
+    const params = query ? `?q=${encodeURIComponent(query)}` : '';
+    fetch(`/api/jobs${params}`)
+      .then(res => {
+        if (res.ok) return res.json();
+        throw new Error('API unavailable');
+      })
+      .catch(() => {
+        return fetch('jobs.json').then(r => r.json());
+      })
+      .then(data => {
+        if (params) {
+          const q = query.toLowerCase();
+          data = data.filter(
+            j =>
+              j.company.toLowerCase().includes(q) ||
+              j.title.toLowerCase().includes(q)
+          );
+        }
+        setJobs(data);
+      })
+      .catch(err => console.error('Failed to fetch jobs', err));
+  }, [query]);
+
+  React.useEffect(() => {
+    fetchJobs();
+  }, [fetchJobs]);
+
+  return (
+    <div>
+      <h1>Job Aggregator</h1>
+      <input
+        type="text"
+        placeholder="Search jobs"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+      />
+      <button onClick={fetchJobs}>Search</button>
+      {jobs.length === 0 ? (
+        <p>No jobs available.</p>
+      ) : (
+        jobs.map((job, idx) => (
+          <div key={idx} className="job">
+            <div className="company">{job.company}</div>
+            <div className="title">{job.title}</div>
+            <div className="location">{job.location}</div>
+            <div><a href={job.link} target="_blank" rel="noreferrer">Apply</a></div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+ReactDOM.render(<JobList />, document.getElementById('root'));

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Job Aggregator</title>
+    <script src="https://unpkg.com/react@17/umd/react.production.min.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .job { border-bottom: 1px solid #ccc; padding: 10px 0; }
+        .company { font-weight: bold; }
+        .location { color: #555; }
+    </style>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy the static site
- export jobs to `static/jobs.json` for pages hosting
- provide fallback to `jobs.json` in the React app
- document GitHub Pages hosting instructions

## Testing
- `python -m py_compile job_aggregator.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68599625c68c83219e944dc600cd3fdb